### PR TITLE
Binning mods addendum

### DIFF
--- a/pisa/core/binning.py
+++ b/pisa/core/binning.py
@@ -1156,10 +1156,6 @@ class OneDimBinning(object):
             logging.trace('Incompatible units')
             return False
 
-        if self.bin_names != other.bin_names:
-            logging.trace('Bin names do not match')
-            return False
-
         # TODO: should we force normalization?
         # TODO: Should we use FTYPE_SIGFIGS or # HASH_SIGFIGS?
         if self.normalize_values:
@@ -2907,7 +2903,14 @@ def test_OneDimBinning():
     assert b1.basename_binning == b1.basename_binning
     assert b1.basename_binning == b3.basename_binning
     assert b1.basename_binning != b2.basename_binning
-
+    
+    # Oversampling/downsampling
+    b1_over = b1.oversample(2)
+    b1_down = b1.downsample(2)
+    assert b1_down.is_compat(b1)
+    assert b1.is_compat(b1_over)
+    assert b1_down.is_compat(b1_over)
+    
     logging.debug('len(b1): %s', len(b1))
     logging.debug('b1: %s', b1)
     logging.debug('b2: %s', b2)

--- a/pisa/core/binning.py
+++ b/pisa/core/binning.py
@@ -1248,8 +1248,16 @@ class OneDimBinning(object):
 
         # Include the uppermost bin edge
         new_bin_edges.append(thisbin_new_edges[-1])
-        # Check consistency
-        assert set(old_bin_edges).issubset(set(new_bin_edges))
+        new_bin_edges = np.array(new_bin_edges)
+        # "snap" edges to the exact value of the original binning to deal with numerical
+        # errors
+        if not set(old_bin_edges).issubset(set(new_bin_edges)):
+            for edge in old_bin_edges:
+                is_close_filt = np.isclose(edge, new_bin_edges, **ALLCLOSE_KW)
+                if np.any(is_close_filt):
+                    new_bin_edges[is_close_filt] = edge
+            # Check consistency
+            assert set(old_bin_edges).issubset(set(new_bin_edges))
         return {'bin_edges': new_bin_edges,
                 'units': self.units,
                 'bin_names': None}

--- a/pisa/core/binning.py
+++ b/pisa/core/binning.py
@@ -240,7 +240,7 @@ class OneDimBinning(object):
     #   backwards compatibility (including for state / hashes), both are kept
     #   (for now) as "state" variables. -JLL, April, 2020
 
-    _hash_attrs = ('name', 'tex', 'bin_edges', 'is_log', 'is_lin', 'bin_names')
+    _hash_attrs = ('name', 'tex', 'bin_edges', 'is_log', 'is_lin', 'bin_names', 'units')
 
     def __init__(self, name, tex=None, bin_edges=None, units=None, domain=None,
                  num_bins=None, is_lin=None, is_log=None, bin_names=None):

--- a/pisa/core/binning.py
+++ b/pisa/core/binning.py
@@ -3119,7 +3119,8 @@ def test_MultiDimBinning():
 
     assert binning.oversample(10, 1).shape == (400, 20)
     assert binning.oversample(1, 3).shape == (40, 60)
-
+    assert binning.downsample(4, 2).shape == (10, 10)
+    
     assert binning.oversample(coszen=10, energy=2).shape == (80, 200)
     assert binning.oversample(1, 1) == binning
 
@@ -3139,7 +3140,26 @@ def test_MultiDimBinning():
     binning.to('MeV', None)
     binning.to('MeV', '')
     binning.to(ureg.joule, '')
-
+    
+    oversampled = binning.oversample(10, 3)
+    assert oversampled.shape == (400, 60)
+    downsampled = binning.downsample(4, 2)
+    assert downsampled.shape == (10, 10)
+    
+    over_vols = oversampled.bin_volumes(attach_units=False)
+    down_vols = downsampled.bin_volumes(attach_units=False)
+    norm_vols = binning.bin_volumes(attach_units=False)
+    assert np.isclose(np.sum(over_vols), np.sum(norm_vols), **ALLCLOSE_KW)
+    assert np.isclose(np.sum(down_vols), np.sum(norm_vols), **ALLCLOSE_KW)
+    assert np.isclose(np.sum(down_vols), np.sum(over_vols), **ALLCLOSE_KW)
+    
+    over_vols = oversampled.weighted_bin_volumes(attach_units=False)
+    down_vols = downsampled.weighted_bin_volumes(attach_units=False)
+    norm_vols = binning.weighted_bin_volumes(attach_units=False)
+    assert np.isclose(np.sum(over_vols), np.sum(norm_vols), **ALLCLOSE_KW)
+    assert np.isclose(np.sum(down_vols), np.sum(norm_vols), **ALLCLOSE_KW)
+    assert np.isclose(np.sum(down_vols), np.sum(over_vols), **ALLCLOSE_KW)
+    
     testdir = tempfile.mkdtemp()
     try:
         b_file = os.path.join(testdir, 'multi_dim_binning.json')

--- a/pisa/core/binning.py
+++ b/pisa/core/binning.py
@@ -977,7 +977,7 @@ class OneDimBinning(object):
         if self._weighted_bin_widths is None:
             if self.is_log:
                 self._weighted_bin_widths = (
-                    self.edge_magnitudes[1:] / self.edge_magnitudes[:-1]
+                    np.log(self.edge_magnitudes[1:] / self.edge_magnitudes[:-1])
                 ) * ureg.dimensionless
             else:
                 self._weighted_bin_widths = self.bin_widths

--- a/pisa/core/binning.py
+++ b/pisa/core/binning.py
@@ -1236,12 +1236,11 @@ class OneDimBinning(object):
             return self
 
         if self.is_log:
-            spacing_func = np.logspace
-            old_bin_edges = np.log10(self.edge_magnitudes)
+            spacing_func = np.geomspace
         else:  # is_lin
             spacing_func = np.linspace
-            old_bin_edges = self.edge_magnitudes
 
+        old_bin_edges = self.edge_magnitudes
         new_bin_edges = []
         for lower, upper in zip(old_bin_edges[:-1], old_bin_edges[1:]):
             thisbin_new_edges = spacing_func(lower, upper, factor + 1)
@@ -1252,7 +1251,8 @@ class OneDimBinning(object):
 
         # Include the uppermost bin edge
         new_bin_edges.append(thisbin_new_edges[-1])
-
+        # Check consistency
+        assert set(old_bin_edges).issubset(set(new_bin_edges))
         return {'bin_edges': new_bin_edges,
                 'units': self.units,
                 'bin_names': None}


### PR DESCRIPTION
When upsampling logarithmic binnings, numerical errors can occur in single precision. If that happens, we "snap" edges back to their original value. 